### PR TITLE
Changing hotkeys + fixing Windows compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,10 +3,10 @@ const merge = require('lodash.merge');
 const defaultConfig = {
   debug: false,
   hotkeys: {
-    selectCurrentPane: 'Command+Alt+Shift+B',
-    selectCurrentTabPanes: 'Command+Alt+B',
-    selectAllPanes: 'Command+Shift+B',
-    toggleCurrentPane: 'Command+Alt+Control+Shift+B'
+    selectCurrentPane: 'CommandOrControl+Alt+U',
+    selectCurrentTabPanes: 'CommandOrControl+Alt+I',
+    selectAllPanes: 'CommandOrControl+Alt+O',
+    toggleCurrentPane: 'CommandOrControl+Alt+P'
   },
   indicatorStyle: {
     position: 'absolute',


### PR DESCRIPTION
Hello,

I found an issue using this plugin on `Windows` (an probably `Linux`): `hotkeys` are not working because they are declared with `Command` key. As explain on the following documentation https://github.com/electron/electron/blob/master/docs/api/accelerator.md#platform-notice, `Command` key is specific to `MacOS` and has no effect on both `Windows` and `Linux`.
So, I replace `Command` with `CommandOrControl` to make them work on all platforms.

I also had to change hotkeys for `selectCurrentPane` and `toggleCurrentPane` hotkeys otherwise it was the same shortcut. So, I totally redefined `hotkeys` with random keys (`u`, `i`,`o` and `p`) but I am totally open to better ones.

Waiting for your feedback.

Regards,
Herrox.